### PR TITLE
Refactoring of Gson

### DIFF
--- a/src/main/java/com/github/messenger4j/common/GsonFactory.java
+++ b/src/main/java/com/github/messenger4j/common/GsonFactory.java
@@ -1,0 +1,119 @@
+package com.github.messenger4j.common;
+
+import static com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Andriy Koretskyy
+ * @since 0.8.0
+ */
+final class GsonFactory {
+
+    private GsonFactory() {
+    }
+
+    static Gson createGson() {
+        return new GsonBuilder()
+                .registerTypeAdapterFactory(new LowercaseEnumTypeAdapterFactory())
+                .registerTypeAdapter(Float.class, new FloatSerializer())
+                .setFieldNamingPolicy(LOWER_CASE_WITH_UNDERSCORES)
+                .create();
+    }
+
+    /**
+     * @author Max Grabenhorst
+     * @since 0.8.0
+     */
+    private static final class FloatSerializer implements JsonSerializer<Float> {
+        @Override
+        public JsonElement serialize(Float floatValue, Type type, JsonSerializationContext jsonSerializationContext) {
+            if (floatValue.isNaN() || floatValue.isInfinite()) {
+                return null;
+            }
+            return new JsonPrimitive(new BigDecimal(floatValue).setScale(2, BigDecimal.ROUND_HALF_UP));
+        }
+    }
+
+    /**
+     * @author Andriy Koretskyy
+     * @since 0.8.0
+     */
+    private static final class LowercaseEnumTypeAdapterFactory implements TypeAdapterFactory {
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+
+            @SuppressWarnings("unchecked")
+            final Class<T> rawType = (Class<T>) type.getRawType();
+            if (!rawType.isEnum()) {
+                return null;
+            }
+
+            final TypeAdapter<T> delegateAdapter = gson.getDelegateAdapter(this, type);
+            final Map<String, T> transformedToConstant = new HashMap<>();
+            final Map<T, String> constantToTransformed = new HashMap<>();
+            for (T constant : rawType.getEnumConstants()) {
+                final String transformedConstant = transform(constant, delegateAdapter);
+                transformedToConstant.put(transformedConstant, constant);
+                constantToTransformed.put(constant, transformedConstant);
+            }
+
+            return new TypeAdapter<T>() {
+                @Override
+                public void write(JsonWriter out, T value) throws IOException {
+                    if (value == null) {
+                        out.nullValue();
+                    } else {
+                        out.value(constantToTransformed.get(value));
+                    }
+                }
+
+                @Override
+                public T read(JsonReader reader) throws IOException {
+                    if (reader.peek() == JsonToken.NULL) {
+                        reader.nextNull();
+                        return null;
+                    } else {
+                        return transformedToConstant.get(reader.nextString());
+                    }
+                }
+            };
+        }
+
+        /**
+         * Transforms the given enum constant to lower case. If a {@code SerializedName} annotation is present,
+         * default adpter result is returned.
+         *
+         * @param enumVal             the enumeration constant
+         * @param delegateAdapter     default adapter in case if enum value has {@code SerializedName} annotation
+         * @return the transformed string representation of the constant
+         */
+        private <T> String transform(T enumVal, TypeAdapter<T> delegateAdapter) {
+            boolean hasSerializedNameAnnotation = false;
+            String enumValue = ((Enum)enumVal).name();
+            try {
+                hasSerializedNameAnnotation = enumVal.getClass().getField(enumValue).isAnnotationPresent(SerializedName.class);
+            } catch (NoSuchFieldException e) {
+                // should never happen
+            }
+            return hasSerializedNameAnnotation ? delegateAdapter.toJsonTree(enumVal).getAsString() : enumValue.toLowerCase();
+        }
+    }
+}

--- a/src/main/java/com/github/messenger4j/common/MessengerSendClientAbstract.java
+++ b/src/main/java/com/github/messenger4j/common/MessengerSendClientAbstract.java
@@ -4,15 +4,9 @@ import com.github.messenger4j.common.MessengerHttpClient.HttpResponse;
 import com.github.messenger4j.exceptions.MessengerApiException;
 import com.github.messenger4j.exceptions.MessengerIOException;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 import java.io.IOException;
-import java.math.BigDecimal;
 
 /**
  * @author Max Grabenhorst
@@ -27,7 +21,7 @@ public abstract class MessengerSendClientAbstract<P, R> {
     private final MessengerHttpClient httpClient;
 
     protected MessengerSendClientAbstract(String requestUrl, MessengerHttpClient httpClient) {
-        this.gson = new GsonBuilder().registerTypeAdapter(Float.class, floatSerializer()).create();
+        this.gson = GsonFactory.createGson();
         this.jsonParser = new JsonParser();
         this.requestUrl = requestUrl;
         this.httpClient = httpClient;
@@ -53,14 +47,4 @@ public abstract class MessengerSendClientAbstract<P, R> {
 
     protected abstract R responseFromJson(JsonObject responseJsonObject);
 
-    private JsonSerializer<Float> floatSerializer() {
-        return new JsonSerializer<Float>() {
-            public JsonElement serialize(Float floatValue, java.lang.reflect.Type type, JsonSerializationContext context) {
-                if (floatValue.isNaN() || floatValue.isInfinite()) {
-                    return null;
-                }
-                return new JsonPrimitive(new BigDecimal(floatValue).setScale(2, BigDecimal.ROUND_HALF_UP));
-            }
-        };
-    }
 }

--- a/src/main/java/com/github/messenger4j/common/WebviewHeightRatio.java
+++ b/src/main/java/com/github/messenger4j/common/WebviewHeightRatio.java
@@ -1,19 +1,11 @@
 package com.github.messenger4j.common;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * @author Max Grabenhorst
  * @since 0.6.0
  */
 public enum WebviewHeightRatio {
-
-    @SerializedName("compact")
     COMPACT,
-
-    @SerializedName("tall")
     TALL,
-
-    @SerializedName("full")
     FULL
 }

--- a/src/main/java/com/github/messenger4j/send/BinaryAttachment.java
+++ b/src/main/java/com/github/messenger4j/send/BinaryAttachment.java
@@ -1,7 +1,7 @@
 package com.github.messenger4j.send;
 
 import com.github.messenger4j.internal.PreConditions;
-import com.google.gson.annotations.SerializedName;
+
 import java.util.Objects;
 
 /**
@@ -62,13 +62,9 @@ public final class BinaryAttachment extends Message.Attachment {
      * @since 0.6.0
      */
     public enum Type {
-        @SerializedName("image")
         IMAGE,
-        @SerializedName("audio")
         AUDIO,
-        @SerializedName("video")
         VIDEO,
-        @SerializedName("file")
         FILE;
     }
 
@@ -79,9 +75,7 @@ public final class BinaryAttachment extends Message.Attachment {
     public static final class Payload {
 
         private final String url;
-        @SerializedName("is_reusable")
         private final Boolean isReusable;
-        @SerializedName("attachment_id")
         private final String attachmentId;
 
         private Payload(String url, Boolean isReusable) {

--- a/src/main/java/com/github/messenger4j/send/Message.java
+++ b/src/main/java/com/github/messenger4j/send/Message.java
@@ -2,7 +2,7 @@ package com.github.messenger4j.send;
 
 import com.github.messenger4j.internal.PreConditions;
 import com.github.messenger4j.send.templates.Template;
-import com.google.gson.annotations.SerializedName;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -14,7 +14,6 @@ final class Message {
 
     private final String text;
     private final Attachment attachment;
-    @SerializedName("quick_replies")
     private final List<QuickReply> quickReplies;
     private final String metadata;
 

--- a/src/main/java/com/github/messenger4j/send/MessagingPayload.java
+++ b/src/main/java/com/github/messenger4j/send/MessagingPayload.java
@@ -1,7 +1,7 @@
 package com.github.messenger4j.send;
 
 import com.github.messenger4j.internal.PreConditions;
-import com.google.gson.annotations.SerializedName;
+
 import java.util.Objects;
 
 /**
@@ -11,10 +11,8 @@ import java.util.Objects;
 final class MessagingPayload {
 
     private final Recipient recipient;
-    @SerializedName("notification_type")
     private final NotificationType notificationType;
     private final Message message;
-    @SerializedName("sender_action")
     private final SenderAction senderAction;
 
     static Builder newBuilder(Recipient recipient) {

--- a/src/main/java/com/github/messenger4j/send/MessengerResponse.java
+++ b/src/main/java/com/github/messenger4j/send/MessengerResponse.java
@@ -1,12 +1,13 @@
 package com.github.messenger4j.send;
 
+import com.google.gson.JsonObject;
+
+import java.util.Objects;
+
 import static com.github.messenger4j.internal.JsonHelper.Constants.PROP_ATTACHMENT_ID;
 import static com.github.messenger4j.internal.JsonHelper.Constants.PROP_MESSAGE_ID;
 import static com.github.messenger4j.internal.JsonHelper.Constants.PROP_RECIPIENT_ID;
 import static com.github.messenger4j.internal.JsonHelper.getPropertyAsString;
-
-import com.google.gson.JsonObject;
-import java.util.Objects;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/send/MessengerSendClientImpl.java
+++ b/src/main/java/com/github/messenger4j/send/MessengerSendClientImpl.java
@@ -8,8 +8,9 @@ import com.github.messenger4j.exceptions.MessengerApiException;
 import com.github.messenger4j.exceptions.MessengerIOException;
 import com.github.messenger4j.internal.PreConditions;
 import com.github.messenger4j.send.templates.Template;
-import com.google.gson.JsonObject;
 import java.util.List;
+
+import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/github/messenger4j/send/NotificationType.java
+++ b/src/main/java/com/github/messenger4j/send/NotificationType.java
@@ -1,5 +1,7 @@
 package com.github.messenger4j.send;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * @author Max Grabenhorst
  * @since 0.6.0
@@ -9,15 +11,18 @@ public enum NotificationType {
     /**
      * Will emit a sound/vibration and a phone notification.
      */
+    @SerializedName("REGULAR")
     REGULAR,
 
     /**
      * Will just emit a phone notification.
      */
+    @SerializedName("SILENT_PUSH")
     SILENT_PUSH,
 
     /**
      * Will not emit either.
      */
+    @SerializedName("NO_PUSH")
     NO_PUSH
 }

--- a/src/main/java/com/github/messenger4j/send/QuickReply.java
+++ b/src/main/java/com/github/messenger4j/send/QuickReply.java
@@ -13,11 +13,9 @@ import java.util.Objects;
  */
 public final class QuickReply {
 
-    @SerializedName("content_type")
     private final ContentType contentType;
     private final String title;
     private final String payload;
-    @SerializedName("image_url")
     private final String imageUrl;
 
     public static ListBuilder newListBuilder() {
@@ -85,9 +83,7 @@ public final class QuickReply {
      * @since 0.6.0
      */
     public enum ContentType {
-        @SerializedName("text")
         TEXT,
-        @SerializedName("location")
         LOCATION
     }
 

--- a/src/main/java/com/github/messenger4j/send/Recipient.java
+++ b/src/main/java/com/github/messenger4j/send/Recipient.java
@@ -1,7 +1,7 @@
 package com.github.messenger4j.send;
 
 import com.github.messenger4j.internal.PreConditions;
-import com.google.gson.annotations.SerializedName;
+
 import java.util.Objects;
 
 /**
@@ -11,7 +11,6 @@ import java.util.Objects;
 public final class Recipient {
 
     private final String id;
-    @SerializedName("phone_number")
     private final String phoneNumber;
 
     public static Builder newBuilder() {

--- a/src/main/java/com/github/messenger4j/send/SenderAction.java
+++ b/src/main/java/com/github/messenger4j/send/SenderAction.java
@@ -1,7 +1,5 @@
 package com.github.messenger4j.send;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * @author Max Grabenhorst
  * @since 0.6.0
@@ -11,19 +9,16 @@ public enum SenderAction {
     /**
      * Mark last message as read.
      */
-    @SerializedName("mark_seen")
     MARK_SEEN,
 
     /**
      * Turn typing indicators on.
      * Typing indicators are automatically turned off after 20 seconds.
      */
-    @SerializedName("typing_on")
     TYPING_ON,
 
     /**
      * Turn typing indicators off.
      */
-    @SerializedName("typing_off")
     TYPING_OFF
 }

--- a/src/main/java/com/github/messenger4j/send/TemplateAttachment.java
+++ b/src/main/java/com/github/messenger4j/send/TemplateAttachment.java
@@ -1,7 +1,7 @@
 package com.github.messenger4j.send;
 
 import com.github.messenger4j.send.templates.Template;
-import com.google.gson.annotations.SerializedName;
+
 import java.util.Objects;
 
 /**
@@ -49,7 +49,6 @@ final class TemplateAttachment extends Message.Attachment {
      * @since 0.6.0
      */
     private enum Type {
-        @SerializedName("template")
         TEMPLATE
     }
 }

--- a/src/main/java/com/github/messenger4j/send/buttons/Button.java
+++ b/src/main/java/com/github/messenger4j/send/buttons/Button.java
@@ -1,6 +1,5 @@
 package com.github.messenger4j.send.buttons;
 
-import com.google.gson.annotations.SerializedName;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -99,23 +98,11 @@ public abstract class Button {
      * @since 0.6.0
      */
     public enum ButtonType {
-
-        @SerializedName("web_url")
-        URL,
-
-        @SerializedName("postback")
+        WEB_URL,
         POSTBACK,
-
-        @SerializedName("phone_number")
-        CALL,
-
-        @SerializedName("element_share")
-        SHARE,
-
-        @SerializedName("account_link")
+        PHONE_NUMBER,
+        ELEMENT_SHARE,
         ACCOUNT_LINK,
-
-        @SerializedName("account_unlink")
         ACCOUNT_UNLINK
     }
 

--- a/src/main/java/com/github/messenger4j/send/buttons/CallButton.java
+++ b/src/main/java/com/github/messenger4j/send/buttons/CallButton.java
@@ -12,7 +12,7 @@ public final class CallButton extends TitleButton {
     private final String payload;
 
     private CallButton(Builder builder) {
-        super(ButtonType.CALL, builder.title);
+        super(ButtonType.PHONE_NUMBER, builder.title);
         payload = builder.payload;
     }
 

--- a/src/main/java/com/github/messenger4j/send/buttons/ShareButton.java
+++ b/src/main/java/com/github/messenger4j/send/buttons/ShareButton.java
@@ -7,7 +7,7 @@ package com.github.messenger4j.send.buttons;
 public final class ShareButton extends Button {
 
     private ShareButton() {
-        super(ButtonType.SHARE);
+        super(ButtonType.ELEMENT_SHARE);
     }
 
     @Override

--- a/src/main/java/com/github/messenger4j/send/buttons/UrlButton.java
+++ b/src/main/java/com/github/messenger4j/send/buttons/UrlButton.java
@@ -2,7 +2,7 @@ package com.github.messenger4j.send.buttons;
 
 import com.github.messenger4j.common.WebviewHeightRatio;
 import com.github.messenger4j.internal.PreConditions;
-import com.google.gson.annotations.SerializedName;
+
 import java.util.Objects;
 
 /**
@@ -12,11 +12,10 @@ import java.util.Objects;
 public final class UrlButton extends TitleButton {
 
     private final String url;
-    @SerializedName("webview_height_ratio")
     private final WebviewHeightRatio webviewHeightRatio;
 
     private UrlButton(Builder builder) {
-        super(ButtonType.URL, builder.title);
+        super(ButtonType.WEB_URL, builder.title);
         url = builder.url;
         webviewHeightRatio = builder.webviewHeightRatio;
     }

--- a/src/main/java/com/github/messenger4j/send/templates/GenericTemplate.java
+++ b/src/main/java/com/github/messenger4j/send/templates/GenericTemplate.java
@@ -2,7 +2,7 @@ package com.github.messenger4j.send.templates;
 
 import com.github.messenger4j.internal.PreConditions;
 import com.github.messenger4j.send.buttons.Button;
-import com.google.gson.annotations.SerializedName;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -86,9 +86,7 @@ public final class GenericTemplate extends Template {
     public static final class Element {
 
         private final String title;
-        @SerializedName("item_url")
         private final String itemUrl;
-        @SerializedName("image_url")
         private final String imageUrl;
         private final String subtitle;
         private final List<Button> buttons;

--- a/src/main/java/com/github/messenger4j/send/templates/ListTemplate.java
+++ b/src/main/java/com/github/messenger4j/send/templates/ListTemplate.java
@@ -3,7 +3,7 @@ package com.github.messenger4j.send.templates;
 import com.github.messenger4j.common.WebviewHeightRatio;
 import com.github.messenger4j.internal.PreConditions;
 import com.github.messenger4j.send.buttons.Button;
-import com.google.gson.annotations.SerializedName;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -15,7 +15,6 @@ import java.util.Objects;
  */
 public final class ListTemplate extends Template {
 
-    @SerializedName("top_element_style")
     private final TopElementStyle topElementStyle;
     private final List<Button> buttons;
     private final List<Element> elements;
@@ -32,10 +31,7 @@ public final class ListTemplate extends Template {
     }
 
     public enum TopElementStyle {
-        @SerializedName("large")
         LARGE,
-
-        @SerializedName("compact")
         COMPACT
     }
 
@@ -111,10 +107,8 @@ public final class ListTemplate extends Template {
 
         private final String title;
         private final String subtitle;
-        @SerializedName("image_url")
         private final String imageUrl;
         private final List<Button> buttons;
-        @SerializedName("default_action")
         private final DefaultAction defaultAction;
 
         private Element(Builder builder) {
@@ -249,13 +243,12 @@ public final class ListTemplate extends Template {
 
             private final Button.ButtonType type;
             private final String url;
-            @SerializedName("webview_height_ratio")
             private final WebviewHeightRatio webviewHeightRatio;
 
             public DefaultAction(Builder builder) {
                 this.url = builder.url;
                 this.webviewHeightRatio = builder.webviewHeightRatio;
-                this.type = Button.ButtonType.URL;
+                this.type = Button.ButtonType.WEB_URL;
             }
 
             @Override

--- a/src/main/java/com/github/messenger4j/send/templates/ReceiptTemplate.java
+++ b/src/main/java/com/github/messenger4j/send/templates/ReceiptTemplate.java
@@ -13,17 +13,12 @@ import java.util.Objects;
  */
 public final class ReceiptTemplate extends Template {
 
-    @SerializedName("recipient_name")
     private final String recipientName;
-    @SerializedName("merchant_name")
     private final String merchantName;
-    @SerializedName("order_number")
     private final String orderNumber;
     private final String currency;
-    @SerializedName("payment_method")
     private final String paymentMethod;
     private final String timestamp;
-    @SerializedName("order_url")
     private final String orderUrl;
     private final List<Element> elements;
     private final ShippingAddress address;
@@ -224,11 +219,8 @@ public final class ReceiptTemplate extends Template {
      */
     public static final class Summary {
 
-        @SerializedName("total_cost")
         private final Float totalCost;
-        @SerializedName("total_tax")
         private final Float totalTax;
-        @SerializedName("shipping_cost")
         private final Float shippingCost;
         private final Float subtotal;
 
@@ -329,7 +321,6 @@ public final class ReceiptTemplate extends Template {
         private final Integer quantity;
         private final Float price;
         private final String currency;
-        @SerializedName("image_url")
         private final String imageUrl;
 
         private Element(Builder builder) {
@@ -482,7 +473,6 @@ public final class ReceiptTemplate extends Template {
         @SerializedName("street_2")
         private final String street2;
         private final String city;
-        @SerializedName("postal_code")
         private final String postalCode;
         private final String state;
         private final String country;

--- a/src/main/java/com/github/messenger4j/send/templates/Template.java
+++ b/src/main/java/com/github/messenger4j/send/templates/Template.java
@@ -1,6 +1,5 @@
 package com.github.messenger4j.send.templates;
 
-import com.google.gson.annotations.SerializedName;
 import java.util.Objects;
 
 /**
@@ -9,15 +8,14 @@ import java.util.Objects;
  */
 public abstract class Template {
 
-    @SerializedName("template_type")
-    private final TemplateType type;
+    private final TemplateType templateType;
 
-    Template(TemplateType type) {
-        this.type = type;
+    Template(TemplateType templateType) {
+        this.templateType = templateType;
     }
 
-    public TemplateType getType() {
-        return type;
+    public TemplateType getTemplateType() {
+        return templateType;
     }
 
     @Override
@@ -25,18 +23,18 @@ public abstract class Template {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Template template = (Template) o;
-        return type == template.type;
+        return templateType == template.templateType;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type);
+        return Objects.hash(templateType);
     }
 
     @Override
     public String toString() {
         return "Template{" +
-                "type=" + type +
+                "templateType=" + templateType +
                 '}';
     }
 
@@ -46,16 +44,9 @@ public abstract class Template {
      */
     public enum TemplateType {
 
-        @SerializedName("generic")
         GENERIC,
-
-        @SerializedName("receipt")
         RECEIPT,
-
-        @SerializedName("button")
         BUTTON,
-
-        @SerializedName("list")
         LIST
     }
 }

--- a/src/main/java/com/github/messenger4j/setup/CallToAction.java
+++ b/src/main/java/com/github/messenger4j/setup/CallToAction.java
@@ -1,11 +1,11 @@
 package com.github.messenger4j.setup;
 
 import static com.github.messenger4j.setup.CallToActionType.POSTBACK;
-import static com.github.messenger4j.setup.CallToActionType.URL;
+import static com.github.messenger4j.setup.CallToActionType.WEB_URL;
 
 import com.github.messenger4j.common.WebviewHeightRatio;
 import com.github.messenger4j.internal.PreConditions;
-import com.google.gson.annotations.SerializedName;
+
 import java.net.URL;
 import java.util.Objects;
 
@@ -19,7 +19,6 @@ public final class CallToAction {
     private final String title;
     private final URL url;
     private final String payload;
-    @SerializedName("webview_height_ratio")
     private final WebviewHeightRatio webviewHeightRatio;
 
     public static CallToAction.Builder newBuilder() {
@@ -127,7 +126,7 @@ public final class CallToAction {
         public CallToAction build() {
             PreConditions.notNull(callToActionType, "type");
             PreConditions.notNullOrBlank(title, "title");
-            if (callToActionType == URL) {
+            if (callToActionType == WEB_URL) {
                 PreConditions.notNull(url, "url");
             }
 

--- a/src/main/java/com/github/messenger4j/setup/CallToActionType.java
+++ b/src/main/java/com/github/messenger4j/setup/CallToActionType.java
@@ -1,16 +1,11 @@
 package com.github.messenger4j.setup;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * @author Andriy Koretskyy
  * @since 0.8.0
  */
 public enum CallToActionType {
 
-    @SerializedName("web_url")
-    URL,
-
-    @SerializedName("postback")
+    WEB_URL,
     POSTBACK
 }

--- a/src/main/java/com/github/messenger4j/setup/MessengerSetupClientImpl.java
+++ b/src/main/java/com/github/messenger4j/setup/MessengerSetupClientImpl.java
@@ -10,8 +10,10 @@ import com.github.messenger4j.common.DefaultMessengerHttpClient;
 import com.github.messenger4j.common.MessengerSendClientAbstract;
 import com.github.messenger4j.exceptions.MessengerApiException;
 import com.github.messenger4j.exceptions.MessengerIOException;
-import com.google.gson.JsonObject;
+
 import java.util.List;
+
+import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/github/messenger4j/setup/SettingType.java
+++ b/src/main/java/com/github/messenger4j/setup/SettingType.java
@@ -1,16 +1,11 @@
 package com.github.messenger4j.setup;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * @author Andriy Koretskyy
  * @since 0.8.0
  */
 enum SettingType {
 
-    @SerializedName("greeting")
     GREETING,
-
-    @SerializedName("call_to_actions")
     CALL_TO_ACTIONS
 }

--- a/src/main/java/com/github/messenger4j/setup/SetupPayload.java
+++ b/src/main/java/com/github/messenger4j/setup/SetupPayload.java
@@ -3,7 +3,6 @@ package com.github.messenger4j.setup;
 import static java.util.Collections.singletonList;
 
 import com.github.messenger4j.internal.PreConditions;
-import com.google.gson.annotations.SerializedName;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -15,13 +14,10 @@ import java.util.List;
  */
 final class SetupPayload {
 
-    @SerializedName("setting_type")
     private final SettingType settingType;
 
-    @SerializedName("thread_state")
     private final ThreadState threadState;
 
-    @SerializedName("call_to_actions")
     private final List<CallToAction> callToActions;
 
     private final Greeting greeting;

--- a/src/main/java/com/github/messenger4j/setup/SetupResponse.java
+++ b/src/main/java/com/github/messenger4j/setup/SetupResponse.java
@@ -1,10 +1,11 @@
 package com.github.messenger4j.setup;
 
+import com.google.gson.JsonObject;
+
+import java.util.Objects;
+
 import static com.github.messenger4j.internal.JsonHelper.Constants.PROP_RESULT;
 import static com.github.messenger4j.internal.JsonHelper.getPropertyAsString;
-
-import com.google.gson.JsonObject;
-import java.util.Objects;
 
 /**
  * @author Andriy Koretskyy

--- a/src/main/java/com/github/messenger4j/setup/ThreadState.java
+++ b/src/main/java/com/github/messenger4j/setup/ThreadState.java
@@ -1,16 +1,11 @@
 package com.github.messenger4j.setup;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * @author Andriy Koretskyy
  * @since 0.8.0
  */
 enum ThreadState {
 
-    @SerializedName("new_thread")
     NEW_THREAD,
-
-    @SerializedName("existing_thread")
     EXISTING_THREAD
 }


### PR DESCRIPTION
- Using FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES instead of explicit SerializedName annotation