### PR TITLE
Support OptInEvent as sent by the Checkbox Plugin

### DIFF
--- a/src/main/java/com/github/messenger4j/internal/gson/GsonUtil.java
+++ b/src/main/java/com/github/messenger4j/internal/gson/GsonUtil.java
@@ -105,6 +105,7 @@ public final class GsonUtil {
         PROP_LAT("lat"),
         PROP_LONG("long"),
         PROP_REF("ref"),
+        PROP_USER_REF("user_ref"),
         PROP_APP_ID("app_id"),
         PROP_METADATA("metadata"),
         PROP_POSTBACK("postback"),

--- a/src/main/java/com/github/messenger4j/webhook/Event.java
+++ b/src/main/java/com/github/messenger4j/webhook/Event.java
@@ -3,6 +3,7 @@ package com.github.messenger4j.webhook;
 import com.github.messenger4j.webhook.event.AccountLinkingEvent;
 import com.github.messenger4j.webhook.event.AttachmentMessageEvent;
 import com.github.messenger4j.webhook.event.BaseEvent;
+import com.github.messenger4j.webhook.event.BaseEventWithSenderId;
 import com.github.messenger4j.webhook.event.MessageDeliveredEvent;
 import com.github.messenger4j.webhook.event.MessageEchoEvent;
 import com.github.messenger4j.webhook.event.MessageReadEvent;
@@ -11,10 +12,15 @@ import com.github.messenger4j.webhook.event.PostbackEvent;
 import com.github.messenger4j.webhook.event.QuickReplyMessageEvent;
 import com.github.messenger4j.webhook.event.ReferralEvent;
 import com.github.messenger4j.webhook.event.TextMessageEvent;
-import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 
 /**
  * @author Max Grabenhorst
@@ -30,8 +36,14 @@ public final class Event {
         this.baseEvent = baseEvent;
     }
 
-    public String senderId() {
-        return baseEvent.senderId();
+    public Optional<String> senderId() {
+        if (isBaseEventWithSenderId()) {
+            return of(asBaseEventWithSenderId().senderId());
+        }
+        if (isOptInEvent()) {
+            return asOptInEvent().senderId();
+        }
+        return empty();
     }
 
     public String recipientId() {
@@ -150,5 +162,16 @@ public final class Event {
             throw new UnsupportedOperationException("not a ReferralEvent");
         }
         return (ReferralEvent) baseEvent;
+    }
+
+    public boolean isBaseEventWithSenderId() {
+        return baseEvent instanceof BaseEventWithSenderId;
+    }
+
+    public BaseEventWithSenderId asBaseEventWithSenderId() {
+        if (!isBaseEventWithSenderId()) {
+            throw new UnsupportedOperationException("not a BaseEventWithSenderId");
+        }
+        return (BaseEventWithSenderId) baseEvent;
     }
 }

--- a/src/main/java/com/github/messenger4j/webhook/Event.java
+++ b/src/main/java/com/github/messenger4j/webhook/Event.java
@@ -1,5 +1,8 @@
 package com.github.messenger4j.webhook;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.github.messenger4j.webhook.event.AccountLinkingEvent;
 import com.github.messenger4j.webhook.event.AttachmentMessageEvent;
 import com.github.messenger4j.webhook.event.BaseEvent;
@@ -12,15 +15,11 @@ import com.github.messenger4j.webhook.event.PostbackEvent;
 import com.github.messenger4j.webhook.event.QuickReplyMessageEvent;
 import com.github.messenger4j.webhook.event.ReferralEvent;
 import com.github.messenger4j.webhook.event.TextMessageEvent;
+import java.time.Instant;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-
-import java.time.Instant;
-import java.util.Optional;
-
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/AccountLinkingEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/AccountLinkingEvent.java
@@ -1,11 +1,10 @@
 package com.github.messenger4j.webhook.event;
 
+import java.time.Instant;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-
-import java.time.Instant;
-import java.util.Optional;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/AccountLinkingEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/AccountLinkingEvent.java
@@ -1,10 +1,11 @@
 package com.github.messenger4j.webhook.event;
 
-import java.time.Instant;
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * @author Max Grabenhorst
@@ -12,7 +13,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class AccountLinkingEvent extends BaseEvent {
+public final class AccountLinkingEvent extends BaseEventWithSenderId {
 
     private final Status status;
     private final Optional<String> authorizationCode;

--- a/src/main/java/com/github/messenger4j/webhook/event/AttachmentMessageEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/AttachmentMessageEvent.java
@@ -2,12 +2,11 @@ package com.github.messenger4j.webhook.event;
 
 import com.github.messenger4j.internal.Lists;
 import com.github.messenger4j.webhook.event.attachment.Attachment;
+import java.time.Instant;
+import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-
-import java.time.Instant;
-import java.util.List;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/AttachmentMessageEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/AttachmentMessageEvent.java
@@ -2,11 +2,12 @@ package com.github.messenger4j.webhook.event;
 
 import com.github.messenger4j.internal.Lists;
 import com.github.messenger4j.webhook.event.attachment.Attachment;
-import java.time.Instant;
-import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
+import java.util.List;
 
 /**
  * @author Max Grabenhorst
@@ -14,7 +15,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class AttachmentMessageEvent extends BaseEvent {
+public final class AttachmentMessageEvent extends BaseEventWithSenderId {
 
     private final String messageId;
     private final List<Attachment> attachments;

--- a/src/main/java/com/github/messenger4j/webhook/event/BaseEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/BaseEvent.java
@@ -1,8 +1,9 @@
 package com.github.messenger4j.webhook.event;
 
-import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+
+import java.time.Instant;
 
 /**
  * @author Max Grabenhorst
@@ -12,18 +13,12 @@ import lombok.ToString;
 @EqualsAndHashCode
 public abstract class BaseEvent {
 
-    private final String senderId;
     private final String recipientId;
     private final Instant timestamp;
 
-    BaseEvent(String senderId, String recipientId, Instant timestamp) {
-        this.senderId = senderId;
+    BaseEvent(String recipientId, Instant timestamp) {
         this.recipientId = recipientId;
         this.timestamp = timestamp;
-    }
-
-    public String senderId() {
-        return senderId;
     }
 
     public String recipientId() {

--- a/src/main/java/com/github/messenger4j/webhook/event/BaseEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/BaseEvent.java
@@ -1,9 +1,8 @@
 package com.github.messenger4j.webhook.event;
 
+import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-
-import java.time.Instant;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/BaseEventWithSenderId.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/BaseEventWithSenderId.java
@@ -1,0 +1,26 @@
+package com.github.messenger4j.webhook.event;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.time.Instant;
+
+/**
+ * @author Joe Tindale
+ * @since 1.0.0-SNAPSHOT
+ */
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public abstract class BaseEventWithSenderId extends BaseEvent {
+
+    private final String senderId;
+
+    BaseEventWithSenderId(String senderId, String recipientId, Instant timestamp) {
+        super(recipientId, timestamp);
+        this.senderId = senderId;
+    }
+
+    public String senderId() {
+        return senderId;
+    }
+}

--- a/src/main/java/com/github/messenger4j/webhook/event/BaseEventWithSenderId.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/BaseEventWithSenderId.java
@@ -1,9 +1,8 @@
 package com.github.messenger4j.webhook.event;
 
+import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-
-import java.time.Instant;
 
 /**
  * @author Joe Tindale

--- a/src/main/java/com/github/messenger4j/webhook/event/FallbackEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/FallbackEvent.java
@@ -1,9 +1,10 @@
 package com.github.messenger4j.webhook.event;
 
-import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
 
 /**
  * @author Max Grabenhorst
@@ -11,7 +12,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class FallbackEvent extends BaseEvent {
+public final class FallbackEvent extends BaseEventWithSenderId {
 
     public FallbackEvent(@NonNull String senderId, @NonNull String recipientId, @NonNull Instant timestamp) {
         super(senderId, recipientId, timestamp);

--- a/src/main/java/com/github/messenger4j/webhook/event/FallbackEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/FallbackEvent.java
@@ -1,10 +1,9 @@
 package com.github.messenger4j.webhook.event;
 
+import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-
-import java.time.Instant;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/MessageDeliveredEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/MessageDeliveredEvent.java
@@ -1,12 +1,13 @@
 package com.github.messenger4j.webhook.event;
 
 import com.github.messenger4j.internal.Lists;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Max Grabenhorst
@@ -14,7 +15,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class MessageDeliveredEvent extends BaseEvent {
+public final class MessageDeliveredEvent extends BaseEventWithSenderId {
 
     private final Instant watermark;
     private final Optional<List<String>> messageIds;

--- a/src/main/java/com/github/messenger4j/webhook/event/MessageDeliveredEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/MessageDeliveredEvent.java
@@ -1,13 +1,12 @@
 package com.github.messenger4j.webhook.event;
 
 import com.github.messenger4j.internal.Lists;
-import lombok.EqualsAndHashCode;
-import lombok.NonNull;
-import lombok.ToString;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/MessageEchoEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/MessageEchoEvent.java
@@ -12,7 +12,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class MessageEchoEvent extends BaseEvent {
+public final class MessageEchoEvent extends BaseEventWithSenderId {
 
     private final String messageId;
     private final String appId;

--- a/src/main/java/com/github/messenger4j/webhook/event/MessageReadEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/MessageReadEvent.java
@@ -1,7 +1,6 @@
 package com.github.messenger4j.webhook.event;
 
 import java.time.Instant;
-
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;

--- a/src/main/java/com/github/messenger4j/webhook/event/MessageReadEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/MessageReadEvent.java
@@ -1,6 +1,7 @@
 package com.github.messenger4j.webhook.event;
 
 import java.time.Instant;
+
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
@@ -11,7 +12,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class MessageReadEvent extends BaseEvent {
+public final class MessageReadEvent extends BaseEventWithSenderId {
 
     private final Instant watermark;
 

--- a/src/main/java/com/github/messenger4j/webhook/event/OptInEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/OptInEvent.java
@@ -1,10 +1,11 @@
 package com.github.messenger4j.webhook.event;
 
-import java.time.Instant;
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * @author Max Grabenhorst
@@ -14,15 +15,27 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 public final class OptInEvent extends BaseEvent {
 
+    private final Optional<String> senderId;
     private final Optional<String> refPayload;
+    private final Optional<String> userRefPayload;
 
-    public OptInEvent(@NonNull String senderId, @NonNull String recipientId, @NonNull Instant timestamp,
-                      @NonNull Optional<String> refPayload) {
-        super(senderId, recipientId, timestamp);
+    public OptInEvent(@NonNull Optional<String> senderId, @NonNull String recipientId, @NonNull Instant timestamp,
+                      @NonNull Optional<String> refPayload, @NonNull Optional<String> userRefPayload) {
+        super(recipientId, timestamp);
+        this.senderId = senderId;
         this.refPayload = refPayload;
+        this.userRefPayload = userRefPayload;
+    }
+
+    public Optional<String> senderId() {
+        return senderId;
     }
 
     public Optional<String> refPayload() {
         return refPayload;
+    }
+
+    public Optional<String> userRefPayload() {
+        return userRefPayload;
     }
 }

--- a/src/main/java/com/github/messenger4j/webhook/event/OptInEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/OptInEvent.java
@@ -1,11 +1,10 @@
 package com.github.messenger4j.webhook.event;
 
+import java.time.Instant;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-
-import java.time.Instant;
-import java.util.Optional;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/PostbackEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/PostbackEvent.java
@@ -1,12 +1,11 @@
 package com.github.messenger4j.webhook.event;
 
 import com.github.messenger4j.webhook.event.common.Referral;
+import java.time.Instant;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-
-import java.time.Instant;
-import java.util.Optional;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/PostbackEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/PostbackEvent.java
@@ -1,11 +1,12 @@
 package com.github.messenger4j.webhook.event;
 
 import com.github.messenger4j.webhook.event.common.Referral;
-import java.time.Instant;
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * @author Max Grabenhorst
@@ -13,7 +14,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class PostbackEvent extends BaseEvent {
+public final class PostbackEvent extends BaseEventWithSenderId {
 
     private final String title;
     private final Optional<String> payload;

--- a/src/main/java/com/github/messenger4j/webhook/event/QuickReplyMessageEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/QuickReplyMessageEvent.java
@@ -1,10 +1,9 @@
 package com.github.messenger4j.webhook.event;
 
+import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-
-import java.time.Instant;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/QuickReplyMessageEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/QuickReplyMessageEvent.java
@@ -1,9 +1,10 @@
 package com.github.messenger4j.webhook.event;
 
-import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
 
 /**
  * @author Max Grabenhorst
@@ -11,7 +12,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class QuickReplyMessageEvent extends BaseEvent {
+public final class QuickReplyMessageEvent extends BaseEventWithSenderId {
 
     private final String messageId;
     private final String text;

--- a/src/main/java/com/github/messenger4j/webhook/event/ReferralEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/ReferralEvent.java
@@ -1,11 +1,10 @@
 package com.github.messenger4j.webhook.event;
 
 import com.github.messenger4j.webhook.event.common.Referral;
+import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-
-import java.time.Instant;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/ReferralEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/ReferralEvent.java
@@ -1,10 +1,11 @@
 package com.github.messenger4j.webhook.event;
 
 import com.github.messenger4j.webhook.event.common.Referral;
-import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
 
 /**
  * @author Max Grabenhorst
@@ -12,7 +13,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class ReferralEvent extends BaseEvent {
+public final class ReferralEvent extends BaseEventWithSenderId {
 
     private final Referral referral;
 

--- a/src/main/java/com/github/messenger4j/webhook/event/TextMessageEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/TextMessageEvent.java
@@ -1,10 +1,9 @@
 package com.github.messenger4j.webhook.event;
 
+import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
-
-import java.time.Instant;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/event/TextMessageEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/TextMessageEvent.java
@@ -1,9 +1,10 @@
 package com.github.messenger4j.webhook.event;
 
-import java.time.Instant;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+
+import java.time.Instant;
 
 /**
  * @author Max Grabenhorst
@@ -11,7 +12,7 @@ import lombok.ToString;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class TextMessageEvent extends BaseEvent {
+public final class TextMessageEvent extends BaseEventWithSenderId {
 
     private final String messageId;
     private final String text;

--- a/src/main/java/com/github/messenger4j/webhook/factory/EventFactory.java
+++ b/src/main/java/com/github/messenger4j/webhook/factory/EventFactory.java
@@ -1,18 +1,19 @@
 package com.github.messenger4j.webhook.factory;
 
+import com.github.messenger4j.internal.Lists;
+import com.github.messenger4j.webhook.Event;
+import com.github.messenger4j.webhook.event.FallbackEvent;
+import com.google.gson.JsonObject;
+
+import java.time.Instant;
+import java.util.List;
+
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_ID;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_RECIPIENT;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_SENDER;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_TIMESTAMP;
 import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsInstant;
 import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsString;
-
-import com.github.messenger4j.internal.Lists;
-import com.github.messenger4j.webhook.Event;
-import com.github.messenger4j.webhook.event.FallbackEvent;
-import com.google.gson.JsonObject;
-import java.time.Instant;
-import java.util.List;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/factory/EventFactory.java
+++ b/src/main/java/com/github/messenger4j/webhook/factory/EventFactory.java
@@ -1,5 +1,12 @@
 package com.github.messenger4j.webhook.factory;
 
+import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_ID;
+import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_RECIPIENT;
+import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_SENDER;
+import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_TIMESTAMP;
+import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsInstant;
+import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsString;
+
 import com.github.messenger4j.internal.Lists;
 import com.github.messenger4j.webhook.Event;
 import com.github.messenger4j.webhook.event.FallbackEvent;
@@ -7,13 +14,6 @@ import com.google.gson.JsonObject;
 
 import java.time.Instant;
 import java.util.List;
-
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_ID;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_RECIPIENT;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_SENDER;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_TIMESTAMP;
-import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsInstant;
-import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsString;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/factory/EventFactory.java
+++ b/src/main/java/com/github/messenger4j/webhook/factory/EventFactory.java
@@ -11,7 +11,6 @@ import com.github.messenger4j.internal.Lists;
 import com.github.messenger4j.webhook.Event;
 import com.github.messenger4j.webhook.event.FallbackEvent;
 import com.google.gson.JsonObject;
-
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/com/github/messenger4j/webhook/factory/OptInEventFactory.java
+++ b/src/main/java/com/github/messenger4j/webhook/factory/OptInEventFactory.java
@@ -1,11 +1,5 @@
 package com.github.messenger4j.webhook.factory;
 
-import com.github.messenger4j.webhook.event.OptInEvent;
-import com.google.gson.JsonObject;
-
-import java.time.Instant;
-import java.util.Optional;
-
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_ID;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_OPTIN;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_RECIPIENT;
@@ -16,6 +10,11 @@ import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_USER_
 import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsInstant;
 import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsString;
 import static com.github.messenger4j.internal.gson.GsonUtil.hasProperty;
+
+import com.github.messenger4j.webhook.event.OptInEvent;
+import com.google.gson.JsonObject;
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * @author Max Grabenhorst

--- a/src/main/java/com/github/messenger4j/webhook/factory/OptInEventFactory.java
+++ b/src/main/java/com/github/messenger4j/webhook/factory/OptInEventFactory.java
@@ -1,19 +1,21 @@
 package com.github.messenger4j.webhook.factory;
 
+import com.github.messenger4j.webhook.event.OptInEvent;
+import com.google.gson.JsonObject;
+
+import java.time.Instant;
+import java.util.Optional;
+
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_ID;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_OPTIN;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_RECIPIENT;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_REF;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_SENDER;
 import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_TIMESTAMP;
+import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_USER_REF;
 import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsInstant;
 import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsString;
 import static com.github.messenger4j.internal.gson.GsonUtil.hasProperty;
-
-import com.github.messenger4j.webhook.event.OptInEvent;
-import com.google.gson.JsonObject;
-import java.time.Instant;
-import java.util.Optional;
 
 /**
  * @author Max Grabenhorst
@@ -28,14 +30,14 @@ final class OptInEventFactory implements BaseEventFactory<OptInEvent> {
 
     @Override
     public OptInEvent createEventFromJson(JsonObject messagingEvent) {
-        final String senderId = getPropertyAsString(messagingEvent, PROP_SENDER, PROP_ID)
-                .orElseThrow(IllegalArgumentException::new);
+        final Optional<String> senderId = getPropertyAsString(messagingEvent, PROP_SENDER, PROP_ID);
         final String recipientId = getPropertyAsString(messagingEvent, PROP_RECIPIENT, PROP_ID)
                 .orElseThrow(IllegalArgumentException::new);
         final Instant timestamp = getPropertyAsInstant(messagingEvent, PROP_TIMESTAMP)
                 .orElseThrow(IllegalArgumentException::new);
         final Optional<String> refPayload = getPropertyAsString(messagingEvent, PROP_OPTIN, PROP_REF);
+        final Optional<String> userRefPayload = getPropertyAsString(messagingEvent, PROP_OPTIN, PROP_USER_REF);
 
-        return new OptInEvent(senderId, recipientId, timestamp, refPayload);
+        return new OptInEvent(senderId, recipientId, timestamp, refPayload, userRefPayload);
     }
 }

--- a/src/test/java/com/github/messenger4j/test/integration/DocumentationTest.java
+++ b/src/test/java/com/github/messenger4j/test/integration/DocumentationTest.java
@@ -1,5 +1,10 @@
 package com.github.messenger4j.test.integration;
 
+import static java.util.Optional.of;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
 import com.github.messenger4j.Messenger;
 import com.github.messenger4j.exception.MessengerApiException;
 import com.github.messenger4j.exception.MessengerIOException;
@@ -13,19 +18,14 @@ import com.github.messenger4j.webhook.event.TextMessageEvent;
 import com.github.messenger4j.webhook.event.attachment.Attachment;
 import com.github.messenger4j.webhook.event.attachment.LocationAttachment;
 import com.github.messenger4j.webhook.event.attachment.RichMediaAttachment;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URL;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import static java.util.Optional.of;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
 
 /**
  * README.adoc examples.

--- a/src/test/java/com/github/messenger4j/test/integration/DocumentationTest.java
+++ b/src/test/java/com/github/messenger4j/test/integration/DocumentationTest.java
@@ -18,7 +18,6 @@ import com.github.messenger4j.webhook.event.TextMessageEvent;
 import com.github.messenger4j.webhook.event.attachment.Attachment;
 import com.github.messenger4j.webhook.event.attachment.LocationAttachment;
 import com.github.messenger4j.webhook.event.attachment.RichMediaAttachment;
-
 import java.io.IOException;
 import java.net.URL;
 import java.time.Instant;

--- a/src/test/java/com/github/messenger4j/test/integration/WebhookTest.java
+++ b/src/test/java/com/github/messenger4j/test/integration/WebhookTest.java
@@ -901,7 +901,8 @@ public class WebhookTest {
         verify(mockEventHandler).accept(eventCaptor.capture());
         final Event event = eventCaptor.getValue();
 
-        assertThat(event.senderId(), equalTo("USER_ID"));
+        assertThat(event.senderId().isPresent(), is(true));
+        assertThat(event.senderId().get(), equalTo("USER_ID"));
         assertThat(event.recipientId(), equalTo("PAGE_ID"));
         assertThat(event.timestamp(), equalTo(Instant.ofEpochMilli(1458692752478L)));
 

--- a/src/test/java/com/github/messenger4j/test/integration/WebhookTest.java
+++ b/src/test/java/com/github/messenger4j/test/integration/WebhookTest.java
@@ -1,5 +1,14 @@
 package com.github.messenger4j.test.integration;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import com.github.messenger4j.Messenger;
 import com.github.messenger4j.exception.MessengerVerificationException;
 import com.github.messenger4j.webhook.Event;
@@ -15,22 +24,12 @@ import com.github.messenger4j.webhook.event.ReferralEvent;
 import com.github.messenger4j.webhook.event.TextMessageEvent;
 import com.github.messenger4j.webhook.event.attachment.Attachment;
 import com.github.messenger4j.webhook.event.attachment.RichMediaAttachment;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.skyscreamer.jsonassert.JSONAssert;
-
 import java.net.URL;
 import java.time.Instant;
 import java.util.function.Consumer;
-
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * @author Max Grabenhorst


### PR DESCRIPTION
This is my first open source PR, so I'm very open to feedback. 

The main changes are to the OptInEvent. I have added support for the optin.user_ref field, but having dug deeper the event sent by Facebook doesn't have a fixed schema. The sender.id property is not present if the event comes from the Checkbox Plugin, but it is present if the event comes from the Send To Messenger plugin. This breaks the BaseEvent abstract class, so I added a class to sit in the inheritance hierarchy between BaseEvent and e.g. TextMessageEvent. I tried to solve this issue using inheritance, but it wasn't 100% clear what the best solution would be. 

I'd welcome any feedback.

Joe