### PR TITLE
Implement nlp support

### DIFF
--- a/src/main/java/com/github/messenger4j/internal/gson/GsonUtil.java
+++ b/src/main/java/com/github/messenger4j/internal/gson/GsonUtil.java
@@ -134,7 +134,9 @@ public final class GsonUtil {
         PROP_SOURCE("source"),
         PROP_AD_ID("ad_id"),
         PROP_IS_PAYMENT_ENABLED("is_payment_enabled"),
-        PROP_LAST_AD_REFERRAL("last_ad_referral");
+        PROP_LAST_AD_REFERRAL("last_ad_referral"),
+        PROP_NLP("nlp"),
+        PROP_ENTITIES("entities");
 
         private final String value;
 

--- a/src/main/java/com/github/messenger4j/webhook/event/TextMessageEvent.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/TextMessageEvent.java
@@ -1,6 +1,11 @@
 package com.github.messenger4j.webhook.event;
 
 import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.github.messenger4j.webhook.event.nlp.NlpEntity;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
@@ -15,12 +20,14 @@ public final class TextMessageEvent extends BaseEvent {
 
     private final String messageId;
     private final String text;
+    private final Optional<Map<String, Set<NlpEntity>>> nlpEntities;
 
     public TextMessageEvent(@NonNull String senderId, @NonNull String recipientId, @NonNull Instant timestamp,
-                            @NonNull String messageId, @NonNull String text) {
+                            @NonNull String messageId, @NonNull String text, Optional<Map<String, Set<NlpEntity>>> nlpEntities) {
         super(senderId, recipientId, timestamp);
         this.messageId = messageId;
         this.text = text;
+        this.nlpEntities = nlpEntities;
     }
 
     public String messageId() {
@@ -29,5 +36,9 @@ public final class TextMessageEvent extends BaseEvent {
 
     public String text() {
         return text;
+    }
+
+    public Optional<Map<String, Set<NlpEntity>>> nlpEntities() {
+        return nlpEntities;
     }
 }

--- a/src/main/java/com/github/messenger4j/webhook/event/nlp/NlpEntity.java
+++ b/src/main/java/com/github/messenger4j/webhook/event/nlp/NlpEntity.java
@@ -1,0 +1,28 @@
+package com.github.messenger4j.webhook.event.nlp;
+
+import com.google.gson.Gson;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * @author Joe Tindale
+ * @since 1.0.0
+ */
+@ToString
+@EqualsAndHashCode
+public class NlpEntity {
+    private final Gson gson = new Gson();
+    private final String json;
+
+    public NlpEntity(String json) {
+        this.json = json;
+    }
+
+    public String asString() {
+        return json;
+    }
+
+    public <T> T as(Class<T> classOfT) {
+        return gson.fromJson(json, classOfT);
+    }
+}


### PR DESCRIPTION
The PR extracts the nlp section of TextMessageEvents. 

Initially the idea was to extract the nlp.entities as a Map<String, Set<JsonObject>>, where the String is the key of the entity, and the Set<JsonObject> is the detected values. Although there are properties that most entities share (such as 'confidence', 'value', and 'start' and 'end' if verbose mode is enabled), the Wit.ai docs show that there are multiple exceptions to the rule (https://wit.ai/docs/http/20170307#entities-format). For this reason, I thought it was better to require the caller to specify the exact shape of the expected entity JSON object. 

I added the NlpEntities class which wraps the json tree and lets the caller expect a certain Java class as the type of the entity. I also let the caller access the raw tree if s/he needs it.

Let me know whether you agree with this approach. I tried to provide a good level of type safety without requiring that the developer knows exactly what might be returned in the nlp section of the Facebook webhook.