### PR TITLE
Add support for email and phone number quick replies

### DIFF
--- a/src/main/java/com/github/messenger4j/send/message/quickreply/QuickReply.java
+++ b/src/main/java/com/github/messenger4j/send/message/quickreply/QuickReply.java
@@ -26,6 +26,8 @@ public abstract class QuickReply {
      */
     public enum ContentType {
         TEXT,
-        LOCATION
+        LOCATION,
+        USER_EMAIL,
+        USER_PHONE_NUMBER
     }
 }

--- a/src/main/java/com/github/messenger4j/send/message/quickreply/UserEmailQuickReply.java
+++ b/src/main/java/com/github/messenger4j/send/message/quickreply/UserEmailQuickReply.java
@@ -1,0 +1,21 @@
+package com.github.messenger4j.send.message.quickreply;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * @author Joe Tindale
+ * @since 1.0.0
+ */
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class UserEmailQuickReply extends QuickReply {
+
+    public static UserEmailQuickReply create() {
+        return new UserEmailQuickReply();
+    }
+
+    private UserEmailQuickReply() {
+        super(ContentType.USER_EMAIL);
+    }
+}

--- a/src/main/java/com/github/messenger4j/send/message/quickreply/UserPhoneNumberQuickReply.java
+++ b/src/main/java/com/github/messenger4j/send/message/quickreply/UserPhoneNumberQuickReply.java
@@ -1,0 +1,21 @@
+package com.github.messenger4j.send.message.quickreply;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * @author Joe Tindale
+ * @since 1.0.0
+ */
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class UserPhoneNumberQuickReply extends QuickReply {
+
+    public static UserPhoneNumberQuickReply create() {
+        return new UserPhoneNumberQuickReply();
+    }
+
+    private UserPhoneNumberQuickReply() {
+        super(ContentType.USER_PHONE_NUMBER);
+    }
+}

--- a/src/test/java/com/github/messenger4j/test/integration/SendTest.java
+++ b/src/test/java/com/github/messenger4j/test/integration/SendTest.java
@@ -33,6 +33,8 @@ import com.github.messenger4j.send.message.TextMessage;
 import com.github.messenger4j.send.message.quickreply.LocationQuickReply;
 import com.github.messenger4j.send.message.quickreply.QuickReply;
 import com.github.messenger4j.send.message.quickreply.TextQuickReply;
+import com.github.messenger4j.send.message.quickreply.UserEmailQuickReply;
+import com.github.messenger4j.send.message.quickreply.UserPhoneNumberQuickReply;
 import com.github.messenger4j.send.message.richmedia.ReusableRichMediaAsset;
 import com.github.messenger4j.send.message.richmedia.UrlRichMediaAsset;
 import com.github.messenger4j.send.message.template.ButtonTemplate;
@@ -262,6 +264,44 @@ public class SendTest {
                 "        \"content_type\":\"text\",\n" +
                 "        \"title\":\"Something Else\",\n" +
                 "        \"payload\":\"<POSTBACK_PAYLOAD>\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "}";
+        verify(mockHttpClient).execute(eq(POST), endsWith(PAGE_ACCESS_TOKEN), payloadCaptor.capture());
+        JSONAssert.assertEquals(expectedJsonBody, payloadCaptor.getValue(), true);
+    }
+
+    @Test
+    public void shouldSendTextMessageWithEmailAndPhoneNumberQuickReplies() throws Exception {
+        final IdRecipient recipient = IdRecipient.create("<PSID>");
+
+        final String text = "Please send us your email or phone number.";
+
+        final UserEmailQuickReply userEmailQuickReply = UserEmailQuickReply.create();
+        final UserPhoneNumberQuickReply userPhoneNumberQuickReply = UserPhoneNumberQuickReply.create();
+
+        final List<QuickReply> quickReplies = Arrays.asList(userEmailQuickReply, userPhoneNumberQuickReply);
+
+        final TextMessage message = TextMessage.create(text, of(quickReplies), empty());
+        final MessagePayload payload = MessagePayload.create(recipient, MessagingType.RESPONSE, message);
+
+        messenger.send(payload);
+
+        final ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+        final String expectedJsonBody = "{\n" +
+                "  \"recipient\":{\n" +
+                "    \"id\":\"<PSID>\"\n" +
+                "  },\n" +
+                "  \"messaging_type\":\"RESPONSE\"," +
+                "  \"message\":{\n" +
+                "    \"text\": \"Please send us your email or phone number.\",\n" +
+                "    \"quick_replies\":[\n" +
+                "      {\n" +
+                "        \"content_type\":\"user_email\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"content_type\":\"user_phone_number\"\n" +
                 "      }\n" +
                 "    ]\n" +
                 "  }\n" +


### PR DESCRIPTION
Hey @maxgrabenhorst, this PR adds support for sending email and phone number quick replies. I added a corresponding issue (https://github.com/messenger4j/messenger4j/issues/76). 

It was a very small amount of work so I decided to go ahead and implement it straight away without discussing it, but feel free to add your feedback and let me know if I should change anything.