### PR TITLE
Hotfix: Fix MessengerApiException while fetching User profile with queryUserProfile method

### DIFF
--- a/src/main/java/com/github/messenger4j/Messenger.java
+++ b/src/main/java/com/github/messenger4j/Messenger.java
@@ -80,7 +80,7 @@ public final class Messenger {
     private static final String FB_GRAPH_API_URL_MESSAGES = "https://graph.facebook.com/v2.11/me/messages?access_token=%s";
     private static final String FB_GRAPH_API_URL_MESSENGER_PROFILE = "https://graph.facebook.com/v2.11/me/messenger_profile?access_token=%s";
     private static final String FB_GRAPH_API_URL_USER = "https://graph.facebook.com/v2.11/%s?fields=first_name," +
-            "last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral&access_token=%s";
+            "last_name,profile_pic,locale,timezone,gender,last_ad_referral&access_token=%s";
 
     private final String pageAccessToken;
     private final String appSecret;

--- a/src/main/java/com/github/messenger4j/Messenger.java
+++ b/src/main/java/com/github/messenger4j/Messenger.java
@@ -80,7 +80,7 @@ public final class Messenger {
     private static final String FB_GRAPH_API_URL_MESSAGES = "https://graph.facebook.com/v2.11/me/messages?access_token=%s";
     private static final String FB_GRAPH_API_URL_MESSENGER_PROFILE = "https://graph.facebook.com/v2.11/me/messenger_profile?access_token=%s";
     private static final String FB_GRAPH_API_URL_USER = "https://graph.facebook.com/v2.11/%s?fields=first_name," +
-            "last_name,profile_pic,locale,timezone,gender,last_ad_referral&access_token=%s";
+            "last_name,profile_pic,locale,timezone,gender&access_token=%s";
 
     private final String pageAccessToken;
     private final String appSecret;

--- a/src/main/java/com/github/messenger4j/userprofile/UserProfile.java
+++ b/src/main/java/com/github/messenger4j/userprofile/UserProfile.java
@@ -20,12 +20,9 @@ public final class UserProfile {
     private final String locale;
     private final float timezoneOffset;
     private final Gender gender;
-    private final boolean isPaymentEnabled;
-    private final Optional<Referral> lastAdReferral;
 
     public UserProfile(@NonNull String firstName, @NonNull String lastName, @NonNull String profilePicture,
-                       @NonNull String locale, float timezoneOffset, @NonNull Gender gender, boolean isPaymentEnabled,
-                       @NonNull Optional<Referral> lastAdReferral) {
+                       @NonNull String locale, float timezoneOffset, @NonNull Gender gender) {
 
         this.firstName = firstName;
         this.lastName = lastName;
@@ -33,8 +30,6 @@ public final class UserProfile {
         this.locale = locale;
         this.timezoneOffset = timezoneOffset;
         this.gender = gender;
-        this.isPaymentEnabled = isPaymentEnabled;
-        this.lastAdReferral = lastAdReferral;
     }
 
     public String firstName() {
@@ -59,14 +54,6 @@ public final class UserProfile {
 
     public Gender gender() {
         return gender;
-    }
-
-    public boolean isPaymentEnabled() {
-        return isPaymentEnabled;
-    }
-
-    public Optional<Referral> lastAdReferral() {
-        return lastAdReferral;
     }
 
     /**

--- a/src/main/java/com/github/messenger4j/userprofile/UserProfileFactory.java
+++ b/src/main/java/com/github/messenger4j/userprofile/UserProfileFactory.java
@@ -46,22 +46,7 @@ public final class UserProfileFactory {
                 .map(String::toUpperCase)
                 .map(UserProfile.Gender::valueOf)
                 .orElseThrow(IllegalArgumentException::new);
-        final boolean isPaymentEnabled = getPropertyAsBoolean(jsonObject, PROP_IS_PAYMENT_ENABLED)
-                .orElseThrow(IllegalArgumentException::new);
 
-        final Optional<Referral> lastAdReferral = getPropertyAsJsonObject(jsonObject, PROP_LAST_AD_REFERRAL)
-                .map(referralJsonObject -> {
-                    final String source = getPropertyAsString(referralJsonObject, PROP_SOURCE)
-                            .orElseThrow(IllegalArgumentException::new);
-                    final String type = getPropertyAsString(referralJsonObject, PROP_TYPE)
-                            .orElseThrow(IllegalArgumentException::new);
-                    final String adId = getPropertyAsString(referralJsonObject, PROP_AD_ID)
-                            .orElseThrow(IllegalArgumentException::new);
-                    return of(new Referral(source, type, empty(), of(adId)));
-                })
-                .orElse(empty());
-
-        return new UserProfile(firstName, lastName, profilePic, locale, timezoneOffset, gender,
-                isPaymentEnabled, lastAdReferral);
+        return new UserProfile(firstName, lastName, profilePic, locale, timezoneOffset, gender);
     }
 }

--- a/src/test/java/com/github/messenger4j/test/integration/UserProfileTest.java
+++ b/src/test/java/com/github/messenger4j/test/integration/UserProfileTest.java
@@ -45,13 +45,7 @@ public class UserProfileTest {
                 "__gda__=1470213755_ab17c8c8e3a0a447fed3f272fa2179ce\",\n" +
                 "  \"locale\": \"en_US\",\n" +
                 "  \"timezone\": -7,\n" +
-                "  \"gender\": \"male\",\n" +
-                "  \"is_payment_enabled\": true,\n" +
-                "  \"last_ad_referral\": {\n" +
-                "    \"source\": \"ADS\",\n" +
-                "    \"type\": \"OPEN_THREAD\",\n" +
-                "    \"ad_id\": \"6045246247433\"\n" +
-                "  }\n" +
+                "  \"gender\": \"male\"\n" +
                 "}");
         when(mockHttpClient.execute(eq(GET), anyString(), isNull())).thenReturn(successfulResponse);
 
@@ -71,11 +65,6 @@ public class UserProfileTest {
         assertThat(userProfile.locale(), is(equalTo("en_US")));
         assertThat(userProfile.timezoneOffset(), is(equalTo(-7f)));
         assertThat(userProfile.gender(), is(equalTo(UserProfile.Gender.MALE)));
-        assertThat(userProfile.isPaymentEnabled(), is(true));
-        assertThat(userProfile.lastAdReferral().isPresent(), is(true));
-        assertThat(userProfile.lastAdReferral().get().source(), is(equalTo("ADS")));
-        assertThat(userProfile.lastAdReferral().get().type(), is(equalTo("OPEN_THREAD")));
-        assertThat(userProfile.lastAdReferral().get().adId(), is(equalTo(of("6045246247433"))));
     }
 
     @Test


### PR DESCRIPTION
This hotfix coorects the get User Profile bug.

While requesting User Profile we catch 

* MessengerApiException: (messenger4j#12) is_payment_enabled field is deprecated for versions v3.1 and higher

* MessengerApiException: (messenger4j#12) last_ad_referral field is deprecated for versions v3.1 and higher

As a hotfix we can just remove is_payment_enabled and last_ad_referral  from the requested parameters in FB_GRAPH_API_URL_USER