### PR TITLE
Fixed errors with query user profile

### DIFF
--- a/src/main/java/com/github/messenger4j/Messenger.java
+++ b/src/main/java/com/github/messenger4j/Messenger.java
@@ -77,9 +77,9 @@ public final class Messenger {
     private static final String OBJECT_TYPE_PAGE = "page";
     private static final String HUB_MODE_SUBSCRIBE = "subscribe";
 
-    private static final String FB_GRAPH_API_URL_MESSAGES = "https://graph.facebook.com/v2.11/me/messages?access_token=%s";
-    private static final String FB_GRAPH_API_URL_MESSENGER_PROFILE = "https://graph.facebook.com/v2.11/me/messenger_profile?access_token=%s";
-    private static final String FB_GRAPH_API_URL_USER = "https://graph.facebook.com/v2.11/%s?fields=first_name," +
+    private static final String FB_GRAPH_API_URL_MESSAGES = "https://graph.facebook.com/v3.2/me/messages?access_token=%s";
+    private static final String FB_GRAPH_API_URL_MESSENGER_PROFILE = "https://graph.facebook.com/v3.2/me/messenger_profile?access_token=%s";
+    private static final String FB_GRAPH_API_URL_USER = "https://graph.facebook.com/v3.2/%s?fields=first_name," +
             "last_name,profile_pic,locale,timezone,gender&access_token=%s";
 
     private final String pageAccessToken;

--- a/src/main/java/com/github/messenger4j/Messenger.java
+++ b/src/main/java/com/github/messenger4j/Messenger.java
@@ -80,7 +80,7 @@ public final class Messenger {
     private static final String FB_GRAPH_API_URL_MESSAGES = "https://graph.facebook.com/v2.11/me/messages?access_token=%s";
     private static final String FB_GRAPH_API_URL_MESSENGER_PROFILE = "https://graph.facebook.com/v2.11/me/messenger_profile?access_token=%s";
     private static final String FB_GRAPH_API_URL_USER = "https://graph.facebook.com/v2.11/%s?fields=first_name," +
-            "last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral&access_token=%s";
+            "last_name,profile_pic,locale,timezone,gender&access_token=%s";
 
     private final String pageAccessToken;
     private final String appSecret;

--- a/src/main/java/com/github/messenger4j/internal/gson/GsonUtil.java
+++ b/src/main/java/com/github/messenger4j/internal/gson/GsonUtil.java
@@ -133,8 +133,6 @@ public final class GsonUtil {
         PROP_REFERRAL("referral"),
         PROP_SOURCE("source"),
         PROP_AD_ID("ad_id"),
-        PROP_IS_PAYMENT_ENABLED("is_payment_enabled"),
-        PROP_LAST_AD_REFERRAL("last_ad_referral"),
         PROP_NLP("nlp"),
         PROP_ENTITIES("entities"),
         PROP_PRIOR_MESSAGE("prior_message"),

--- a/src/main/java/com/github/messenger4j/userprofile/UserProfile.java
+++ b/src/main/java/com/github/messenger4j/userprofile/UserProfile.java
@@ -20,12 +20,9 @@ public final class UserProfile {
     private final String locale;
     private final float timezoneOffset;
     private final Gender gender;
-    private final boolean isPaymentEnabled;
-    private final Optional<Referral> lastAdReferral;
 
     public UserProfile(@NonNull String firstName, @NonNull String lastName, @NonNull String profilePicture,
-                       @NonNull String locale, float timezoneOffset, @NonNull Gender gender, boolean isPaymentEnabled,
-                       @NonNull Optional<Referral> lastAdReferral) {
+                       @NonNull String locale, float timezoneOffset, @NonNull Gender gender) {
 
         this.firstName = firstName;
         this.lastName = lastName;
@@ -33,8 +30,6 @@ public final class UserProfile {
         this.locale = locale;
         this.timezoneOffset = timezoneOffset;
         this.gender = gender;
-        this.isPaymentEnabled = isPaymentEnabled;
-        this.lastAdReferral = lastAdReferral;
     }
 
     public String firstName() {
@@ -59,14 +54,6 @@ public final class UserProfile {
 
     public Gender gender() {
         return gender;
-    }
-
-    public boolean isPaymentEnabled() {
-        return isPaymentEnabled;
-    }
-
-    public Optional<Referral> lastAdReferral() {
-        return lastAdReferral;
     }
 
     /**

--- a/src/main/java/com/github/messenger4j/userprofile/UserProfileFactory.java
+++ b/src/main/java/com/github/messenger4j/userprofile/UserProfileFactory.java
@@ -1,26 +1,10 @@
 package com.github.messenger4j.userprofile;
 
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_AD_ID;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_FIRST_NAME;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_GENDER;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_IS_PAYMENT_ENABLED;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_LAST_AD_REFERRAL;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_LAST_NAME;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_LOCALE;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_PROFILE_PIC;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_SOURCE;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_TIMEZONE;
-import static com.github.messenger4j.internal.gson.GsonUtil.Constants.PROP_TYPE;
-import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsBoolean;
-import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsFloat;
-import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsJsonObject;
-import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsString;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-
-import com.github.messenger4j.webhook.event.common.Referral;
 import com.google.gson.JsonObject;
-import java.util.Optional;
+
+import static com.github.messenger4j.internal.gson.GsonUtil.Constants.*;
+import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsFloat;
+import static com.github.messenger4j.internal.gson.GsonUtil.getPropertyAsString;
 
 /**
  * @author Max Grabenhorst
@@ -46,22 +30,7 @@ public final class UserProfileFactory {
                 .map(String::toUpperCase)
                 .map(UserProfile.Gender::valueOf)
                 .orElseThrow(IllegalArgumentException::new);
-        final boolean isPaymentEnabled = getPropertyAsBoolean(jsonObject, PROP_IS_PAYMENT_ENABLED)
-                .orElseThrow(IllegalArgumentException::new);
 
-        final Optional<Referral> lastAdReferral = getPropertyAsJsonObject(jsonObject, PROP_LAST_AD_REFERRAL)
-                .map(referralJsonObject -> {
-                    final String source = getPropertyAsString(referralJsonObject, PROP_SOURCE)
-                            .orElseThrow(IllegalArgumentException::new);
-                    final String type = getPropertyAsString(referralJsonObject, PROP_TYPE)
-                            .orElseThrow(IllegalArgumentException::new);
-                    final String adId = getPropertyAsString(referralJsonObject, PROP_AD_ID)
-                            .orElseThrow(IllegalArgumentException::new);
-                    return of(new Referral(source, type, empty(), of(adId)));
-                })
-                .orElse(empty());
-
-        return new UserProfile(firstName, lastName, profilePic, locale, timezoneOffset, gender,
-                isPaymentEnabled, lastAdReferral);
+        return new UserProfile(firstName, lastName, profilePic, locale, timezoneOffset, gender);
     }
 }

--- a/src/test/java/com/github/messenger4j/test/integration/UserProfileTest.java
+++ b/src/test/java/com/github/messenger4j/test/integration/UserProfileTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
  */
 public class UserProfileTest {
 
-    private static final String FB_GRAPH_API_URL = "https://graph.facebook.com/v2.11/%s?fields=first_name," +
+    private static final String FB_GRAPH_API_URL = "https://graph.facebook.com/v3.2/%s?fields=first_name," +
             "last_name,profile_pic,locale,timezone,gender&access_token=%s";
     private static final String PAGE_ACCESS_TOKEN = "PAGE_ACCESS_TOKEN";
 

--- a/src/test/java/com/github/messenger4j/test/integration/UserProfileTest.java
+++ b/src/test/java/com/github/messenger4j/test/integration/UserProfileTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class UserProfileTest {
 
     private static final String FB_GRAPH_API_URL = "https://graph.facebook.com/v2.11/%s?fields=first_name," +
-            "last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral&access_token=%s";
+            "last_name,profile_pic,locale,timezone,gender&access_token=%s";
     private static final String PAGE_ACCESS_TOKEN = "PAGE_ACCESS_TOKEN";
 
     private final MessengerHttpClient mockHttpClient = mock(MessengerHttpClient.class);
@@ -71,11 +71,6 @@ public class UserProfileTest {
         assertThat(userProfile.locale(), is(equalTo("en_US")));
         assertThat(userProfile.timezoneOffset(), is(equalTo(-7f)));
         assertThat(userProfile.gender(), is(equalTo(UserProfile.Gender.MALE)));
-        assertThat(userProfile.isPaymentEnabled(), is(true));
-        assertThat(userProfile.lastAdReferral().isPresent(), is(true));
-        assertThat(userProfile.lastAdReferral().get().source(), is(equalTo("ADS")));
-        assertThat(userProfile.lastAdReferral().get().type(), is(equalTo("OPEN_THREAD")));
-        assertThat(userProfile.lastAdReferral().get().adId(), is(equalTo(of("6045246247433"))));
     }
 
     @Test


### PR DESCRIPTION
1. Removed fields last_ad_referral and is_payment_enabled
2. Changed Facebook Graph API version from v2.11 to v3.2 

Facebook added some changes to their API and they deprecated fields **last_ad_referral** and **is_payment_enabled**. 
Thus when we try get user profile with user API url which exists in library 
```
https://graph.facebook.com/v2.1/%s?fields=first_name,last_name,profile_pic,locale,timezone,gender&access_token=%s
```


We receive an error:
```
{"error":{"message":"(#100) The last_ad_referral and is_payment_enabled fields are now deprecated. Please refer to our Developer Document for more info.","type":"OAuthException","code":100,"error_subcode":2018254,"fbtrace_id":"C70C1WPQQxV"}}
```

For fix this I removed deprecated fields.
[Facebook Profile API description](https://developers.facebook.com/docs/messenger-platform/identity/user-profile)

Thanks,
Vitaliy